### PR TITLE
Add Workflow dispatch to enable manual running

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch: # This enables the workflow to be manually run in the browser in the 'Actions' Tab
 
 jobs:
   build:


### PR DESCRIPTION
Is helpful when debugging why the online build fails, but the local one does not

:plsplspls: